### PR TITLE
Feat helper fifi

### DIFF
--- a/app/controllers/app.rb
+++ b/app/controllers/app.rb
@@ -2,19 +2,27 @@
 
 require 'roda'
 require 'json'
-require 'logger'
 
+require_relative 'http_request'
 module LostNFound
   # Web controller for LostNFound API
   class Api < Roda
     plugin :halt
     plugin :multi_route
+    plugin :request_headers
 
     route do |routing|
       response['Content-Type'] = 'application/json'
+      request = HttpRequest.new(routing)
 
-      HttpRequest.new(routing).secure? ||
+      request.secure? ||
         routing.halt(403, { message: 'TLS/SSL Required' }.to_json)
+
+      begin
+        @auth_account = request.authenticated_account
+      rescue AuthToken::InvalidTokenError
+        routing.halt 403, { message: 'Invalid auth token' }.to_json
+      end
 
       routing.root do
         { message: 'LostNFound API up at /api/v1' }.to_json

--- a/app/controllers/auth.rb
+++ b/app/controllers/auth.rb
@@ -27,14 +27,13 @@ module LostNFound
         end
       end
 
-      routing.on 'authenticate' do
+      routing.is 'authenticate' do
         # POST /api/v1/auth/authenticate
         routing.post do
           credentials = HttpRequest.new(routing).body_data
           auth_account = AuthenticateAccount.call(credentials)
           auth_account.to_json
-        rescue UnauthorizedError => e
-          puts [e.class, e.message].join ': '
+        rescue AuthenticateAccount::UnauthorizedError
           routing.halt '403', { message: 'Invalid credentials' }.to_json
         end
       end

--- a/app/controllers/http_request.rb
+++ b/app/controllers/http_request.rb
@@ -13,6 +13,14 @@ module LostNFound
       @routing.scheme.casecmp(Api.config.SECURE_SCHEME).zero?
     end
 
+    def authenticated_account
+      return nil unless @routing.headers['AUTHORIZATION']
+
+      scheme, auth_token = @routing.headers['AUTHORIZATION'].split
+      account_payload = AuthToken.new(auth_token).payload
+      scheme.match?(/^Bearer$/i) ? account_payload['attributes'] : nil
+    end
+
     def body_data
       JSON.parse(@routing.body.read, symbolize_names: true)
     end

--- a/app/controllers/items.rb
+++ b/app/controllers/items.rb
@@ -70,13 +70,15 @@ module LostNFound
 
       # GET /api/v1/items
       routing.get do
-        output = { data: Item.all }
-        JSON.pretty_generate(output)
+        account = Account.first(username: @auth_account['username'])
+        items = account.items
+        JSON.pretty_generate(data: items)
+      rescue StandardError
+        routing.halt 403, { message: 'Could not find any items' }.to_json
       end
 
       # POST /api/v1/items
       routing.post do
-        # new_data = HttpRequest.new(routing).body_data
         new_data = JSON.parse(routing.body.read)
 
         # TODO: temporarily use the first account as the owner

--- a/app/services/authenticate_account.rb
+++ b/app/services/authenticate_account.rb
@@ -1,25 +1,37 @@
 # frozen_string_literal: true
 
 module LostNFound
-  # Error for invalid credentials
-  class UnauthorizedError < StandardError
-    def initialize(msg = nil)
-      super
-      @credentials = msg
-    end
-
-    def message
-      "Invalid Credentials for: #{@credentials[:username]}"
-    end
-  end
-
   # Find account and check password
   class AuthenticateAccount
+    # Error for invalid credentials
+    class UnauthorizedError < StandardError
+      def initialize(msg = nil)
+        super
+        @credentials = msg
+      end
+
+      def message
+        "Invalid Credentials for: #{@credentials[:username]}"
+      end
+    end
+
     def self.call(credentials)
       account = Account.first(username: credentials[:username])
-      account.password?(credentials[:password]) ? account : raise
+      raise unless account.password?(credentials[:password])
+
+      account_and_token(account)
     rescue StandardError
-      raise UnauthorizedError, credentials
+      raise UnauthorizedError
+    end
+
+    def self.account_and_token(account)
+      {
+        type: 'authenticated_account',
+        attributes: {
+          account:,
+          auth_token: AuthToken.create(account)
+        }
+      }
     end
   end
 end

--- a/db/migrations/002_items_create.rb
+++ b/db/migrations/002_items_create.rb
@@ -7,7 +7,7 @@ Sequel.migration do
     create_table(:items) do
       uuid :id, primary_key: true
 
-      foreign_key :created_by, :accounts, type: :uuid, null: false
+      foreign_key :created_by, :accounts, type: :uuid # allow column to be null
 
       Integer :type, null: false
       String :name, null: false

--- a/spec/integration/api_auth_spec.rb
+++ b/spec/integration/api_auth_spec.rb
@@ -20,20 +20,16 @@ describe 'Test Authentication Routes' do
       credentials = { username: @account_data['username'],
                       password: @account_data['password'] }
       post '/api/v1/auth/authenticate', credentials.to_json, @req_header
-
       auth_account = JSON.parse(last_response.body)['attributes']
       _(last_response.status).must_equal 200
-      _(auth_account['username']).must_equal(@account_data['username'])
+      _(auth_account['account']['attributes']['username']).must_equal(@account_data['username'])
       _(auth_account['id']).must_be_nil
     end
 
     it 'BAD: should not authenticate invalid password' do
       credentials = { username: @account_data['username'],
                       password: 'fakepassword' }
-      assert_output(/invalid/i, '') do
-        post 'api/v1/auth/authenticate', credentials.to_json, @req_header
-      end
-
+      post 'api/v1/auth/authenticate', credentials.to_json, @req_header
       result = JSON.parse(last_response.body)
 
       _(last_response.status).must_equal 403

--- a/spec/integration/service_authenticate_account_spec.rb
+++ b/spec/integration/service_authenticate_account_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require_relative '../spec_helper'
+
+describe 'Test AddContactToItem service' do
+  before do
+    wipe_database
+
+    DATA[:accounts].each do |account_data|
+      LostNFound::Account.create(account_data)
+    end
+  end
+
+  it 'HAPPY: should authenticate valid account credentials' do
+    credentials = DATA[:accounts].first
+    account = LostNFound::AuthenticateAccount.call(
+      username: credentials['username'], password: credentials['password']
+    )
+    _(account).wont_be_nil
+  end
+
+  it 'SAD: will not authenticate with invalid password' do
+    credentials = DATA[:accounts].first
+    _(proc {
+      LostNFound::AuthenticateAccount.call(
+        username: credentials['username'], password: 'malword'
+      )
+    }).must_raise LostNFound::AuthenticateAccount::UnauthorizedError
+  end
+
+  it 'BAD: will not authenticate with invalid credentials' do
+    _(proc {
+      LostNFound::AuthenticateAccount.call(
+        username: 'maluser', password: 'malword'
+      )
+    }).must_raise LostNFound::AuthenticateAccount::UnauthorizedError
+  end
+end


### PR DESCRIPTION
I changed the item's data structure so that created_by allows null values. "HAPPY: should be able to get details of a single item" would not pass if I don't give it an account first

Credence's projects also allowed null values for account fk, so I'm following that for now, but I think it makes more sense if an account is created before an item @@

The rest of the changes follow the Credence repo

