### PR TITLE
Add Policies in API

### DIFF
--- a/app/controllers/accounts.rb
+++ b/app/controllers/accounts.rb
@@ -12,10 +12,15 @@ module LostNFound
       routing.on String do |username|
         # GET api/v1/accounts/[username]
         routing.get do
-          account = Account.first(username:)
-          account ? account.to_json : raise('Account not found')
-        rescue StandardError => e
+          account = GetAccountQuery.call(
+            requestor: @auth_account, username: username
+          )
+          account.to_json
+        rescue GetAccountQuery::ForbiddenError => e
           routing.halt 404, { message: e.message }.to_json
+        rescue StandardError => e
+          puts "GET ACCOUNT ERROR: #{e.inspect}"
+          routing.halt 500, { message: 'API Server Error' }.to_json
         end
       end
 

--- a/app/controllers/contacts.rb
+++ b/app/controllers/contacts.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require_relative 'app'
+
+module LostNFound
+  # Web controller for LostNFound API - contacts
+  class Api < Roda
+    route('contacts') do |routing|
+      unless @auth_account # rubocop:disable Style/IfUnlessModifier
+        routing.halt 403, { message: 'Not authorized' }.to_json
+      end
+
+      @contact_route = "#{@api_root}/contacts"
+
+      # GET /api/v1/contacts/[contact_id]
+      routing.on String do |contact_id|
+        @req_contact = Contact.first(id: contact_id)
+
+        routing.get do
+          contact = GetContactQuery.call(
+            account: @auth_account, contact_id: contact_id
+          )
+
+          { data: contact }.to_json
+        rescue GetContactQuery::ForbiddenError => e
+          routing.halt 403, { message: e.message }.to_json
+        rescue GetContactQuery::NotFoundError => e
+          routing.halt 404, { message: e.message }.to_json
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/items.rb
+++ b/app/controllers/items.rb
@@ -7,28 +7,38 @@ module LostNFound
   # Web controller for LostNFound API
   class Api < Roda
     route('items') do |routing|
-      @item_route = "#{@api_root}/items"
+      unauthorized_message = { message: 'Unauthorized Request' }.to_json
+      routing.halt(403, unauthorized_message) unless @auth_account
 
+      @item_route = "#{@api_root}/items"
       routing.on String do |item_id|
         routing.on 'contacts' do
           @contacts_route = "#{@api_root}/items/#{item_id}/contacts"
 
           # GET /api/v1/items/:item_id/contacts/:contact_id
           routing.get String do |contact_id|
-            contact = Contact.where(item_id: item_id, id: contact_id).first
-            contact ? contact.to_json : routing.halt(404, { message: 'Contact not found' }.to_json)
+            result = GetContactQuery.call(
+              account: @auth_account,
+              contact_id: contact_id
+            )
+            { data: result }.to_json
+          rescue GetContactQuery::ForbiddenError => e
+            routing.halt 403, { message: e.message }.to_json
+          rescue GetContactQuery::NotFoundError => e
+            routing.halt 404, { message: e.message }.to_json
           rescue StandardError => e
-            Api.logger.error "UNKNOWN ERROR: #{e.message}"
-            routing.halt 500, { message: 'Unknown server error' }.to_json
+            Api.logger.error "UNKNOWN ERROR (GetContact): #{e.full_message}"
+            routing.halt 500, { message: 'Unexpected server error' }.to_json
           end
 
           # GET /api/v1/items/:item_id/contacts
           routing.get do
             item = Item.first(id: item_id)
             routing.halt 404, { message: 'Item not found' }.to_json unless item
+            policy = ContactPolicy.new(@auth_account, item)
+            routing.halt 403, { message: 'Not authorized' }.to_json unless policy.can_view?
 
-            output = { data: item.contacts }
-            JSON.pretty_generate(output)
+            { data: item.contacts.map(&:to_h) }.to_json
           rescue StandardError => e
             Api.logger.error "UNKNOWN ERROR: #{e.message}"
             routing.halt 500, { message: 'Unknown server error' }.to_json
@@ -36,70 +46,70 @@ module LostNFound
 
           # POST /api/v1/items/:item_id/contacts
           routing.post do
-            new_data = JSON.parse(routing.body.read)
             item = Item.first(id: item_id)
-
             routing.halt 404, { message: 'Item not found' }.to_json unless item
+            policy = ContactPolicy.new(@auth_account, item)
+            routing.halt 403, { message: 'Not authorized' }.to_json unless policy.can_edit?
 
+            new_data = JSON.parse(routing.body.read)
             new_contact = CreateContactForItem.call(
               item_id: item.id, contact_data: new_data
             )
 
-            routing.halt 400, { message: 'Could not save contact' }.to_json unless new_contact
             response.status = 201
             response['Location'] = "#{@contacts_route}/#{new_contact.id}"
             { message: 'Contact saved', data: new_contact }.to_json
-          rescue Sequel::MassAssignmentRestriction
-            Api.logger.warn "MASS-ASSIGNMENT: #{new_data.keys}"
-            routing.halt 400, { message: 'Illegal Attributes' }.to_json
           rescue StandardError => e
-            Api.logger.error "UNKNOWN ERROR: #{e.message}"
-            routing.halt 500, { message: 'Unknown server error' }.to_json
+            Api.logger.error "UNKNOWN ERROR (GetItem): #{e.full_message}"
+            routing.halt 500, { message: 'Unexpected server error' }.to_json
           end
         end
 
         # GET /api/v1/items/:item_id
         routing.get do
-          item = Item.first(id: item_id)
-          item ? item.to_json : routing.halt(404, { message: 'Item not found' }.to_json)
+          result = GetItemQuery.call(
+            account: @auth_account,
+            item_id: item_id
+          )
+          { data: result }.to_json
+        rescue GetItemQuery::ForbiddenError => e
+          routing.halt 403, { message: e.message }.to_json
+        rescue GetItemQuery::NotFoundError => e
+          routing.halt 404, { message: e.message }.to_json
+        rescue StandardError => e
+          Api.logger.error "UNKNOWN ERROR (GetItem): #{e.full_message}"
+          routing.halt 500, { message: 'Unexpected server error' }.to_json
+        end
+      end
+
+      routing.is do
+        # GET /api/v1/items
+        routing.get do
+          items = ItemPolicy::AccountScope.new(@auth_account).viewable
+          { data: items.map(&:full_details) }.to_json
+        end
+
+        # POST /api/v1/items
+        routing.post do
+          new_data = JSON.parse(routing.body.read)
+
+          # TODO: temporarily use the first account as the owner
+          # this should be replaced with the actual owner
+          # once the authentication is implemented
+          new_item = CreateItemForOwner.call(
+            owner_id: @auth_account['id'],
+            item_data: new_data
+          )
+          response.status = 201
+          response['Location'] = "#{@item_route}/#{new_item.id}"
+          { message: 'Item saved', data: new_item }.to_json
+        rescue Sequel::MassAssignmentRestriction
+          Api.logger.warn "MASS-ASSIGNMENT: #{new_data.keys}"
+          routing.halt 400, { message: 'Illegal Attributes' }.to_json
         rescue StandardError => e
           Api.logger.error "UNKNOWN ERROR: #{e.message}"
           routing.halt 500, { message: 'Unknown server error' }.to_json
         end
-      end
-
-      # GET /api/v1/items
-      routing.get do
-        account = Account.first(username: @auth_account['username'])
-        items = account.items
-        JSON.pretty_generate(data: items)
-      rescue StandardError
-        routing.halt 403, { message: 'Could not find any items' }.to_json
-      end
-
-      # POST /api/v1/items
-      routing.post do
-        new_data = JSON.parse(routing.body.read)
-
-        # TODO: temporarily use the first account as the owner
-        # this should be replaced with the actual owner
-        # once the authentication is implemented
-        owner = Account.first
-        new_item = CreateItemForOwner.call(
-          owner_id: owner.id,
-          item_data: new_data
-        )
-        routing.halt 400, { message: 'Could not save item' }.to_json unless new_item
-
-        response.status = 201
-        response['Location'] = "#{@item_route}/#{new_item.id}"
-        { message: 'Item saved', data: new_item }.to_json
-      rescue Sequel::MassAssignmentRestriction
-        Api.logger.warn "MASS-ASSIGNMENT: #{new_data.keys}"
-        routing.halt 400, { message: 'Illegal Attributes' }.to_json
-      rescue StandardError => e
-        Api.logger.error "UNKNOWN ERROR: #{e.message}"
-        routing.halt 500, { message: 'Unknown server error' }.to_json
       end
     end
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -21,27 +21,34 @@ module LostNFound
     plugin :whitelist_security
     set_allowed_columns :type, :name, :description, :location, :person_info
 
-    def to_json(options = {}) # rubocop:disable Metrics/MethodLength
-      JSON(
-        {
-          data: {
-            type: 'item',
-            attributes: {
-              id:,
-              type:,
-              name:,
-              description:,
-              location:,
-              person_info:,
-              created_by:,
-              resolved:
-            }
-          },
-          included: {
-            contacts:
-          }
-        }, options
+    def to_h # rubocop:disable Metrics/MethodLength
+      {
+        type: 'item',
+        attributes: {
+          id:,
+          type:,
+          name:,
+          description:,
+          location:,
+          person_info:,
+          created_by:,
+          resolved:
+        }
+      }
+    end
+
+    def full_details
+      to_h.merge(
+        relationships: {
+          creator:,
+          contacts:,
+          tags:
+        }
       )
+    end
+
+    def to_json(options = {})
+      JSON(to_h, options)
     end
   end
 end

--- a/app/policies/account_policy.rb
+++ b/app/policies/account_policy.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Policy to determine if account can view a project
+class AccountPolicy
+  def initialize(requestor, account)
+    @requestor = requestor
+    @account = account
+  end
+
+  def can_view?
+    self_request?
+  end
+
+  def can_update?
+    self_request?
+  end
+
+  def can_delete?
+    self_request?
+  end
+
+  def summary
+    {
+      can_view: can_view?,
+      can_update: can_update?,
+      can_delete: can_delete?
+    }
+  end
+
+  private
+
+  def self_request?
+    @requestor == @account
+  end
+end

--- a/app/policies/contact_policy.rb
+++ b/app/policies/contact_policy.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module LostNFound
+  class ContactPolicy # rubocop:disable Style/Documentation
+    def initialize(requestor, item)
+      @requestor = requestor
+      @item = item
+    end
+
+    def can_view?
+      owns_item?
+    end
+
+    def can_edit?
+      owns_item?
+    end
+
+    def can_delete?
+      owns_item?
+    end
+
+    def summary
+      {
+        can_view: can_view?,
+        can_edit: can_edit?,
+        can_delete: can_delete?
+      }
+    end
+
+    private
+
+    def owns_item?
+      @item.creator == @requestor
+    end
+  end
+end

--- a/app/policies/item_policy.rb
+++ b/app/policies/item_policy.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class ItemPolicy # rubocop:disable Style/Documentation
+  def initialize(account, item)
+    @account = account
+    @item = item
+  end
+
+  def can_create?
+    @account.present?
+  end
+
+  def can_view?
+    true
+  end
+
+  def can_update?
+    owns_item?
+  end
+
+  def can_delete?
+    owns_item?
+  end
+
+  def summary
+    {
+      can_create: can_create?,
+      can_view: can_view?,
+      can_update: can_update?,
+      can_delete: can_delete?
+    }
+  end
+
+  private
+
+  def owns_item?
+    @item.creator == @account
+  end
+end

--- a/app/policies/item_scopes.rb
+++ b/app/policies/item_scopes.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module LostNFound
+  class ItemPolicy
+    # Scope for items viewable by an account
+    class AccountScope
+      def initialize(current_account, target_account = nil)
+        @current_account = current_account
+        @target_account = target_account || current_account
+      end
+
+      def viewable
+        # so far everyone can view items, this is still under construction
+        Item.all
+      end
+    end
+  end
+end

--- a/app/policies/tag_policy.rb
+++ b/app/policies/tag_policy.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class TagPolicy # rubocop:disable Style/Documentation
+  def initialize(requestor, tag)
+    @requestor = requestor
+    @tag = tag
+  end
+
+  def can_create?
+    true
+  end
+
+  def can_view?
+    true
+  end
+
+  def can_update?
+    false # tag model has no creator column, so we assume tags are not editable
+  end
+
+  def can_delete?
+    false # tag model has no creator column, so we assume tags are not deletable
+  end
+
+  def can_add_to_item?(item)
+    item.creator == @requestor
+  end
+
+  def can_remove_from_item?(item)
+    item.creator == @requestor
+  end
+
+  def summary
+    {
+      can_create: can_create?,
+      can_view: can_view?,
+      can_update: can_update?,
+      can_delete: can_delete?,
+      can_add_to_item: can_add_to_item?(item),
+      can_remove_from_item: can_remove_from_item?(item)
+    }
+  end
+end

--- a/app/services/get_account_query.rb
+++ b/app/services/get_account_query.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module LostNFound
+  # Add a collaborator to another owner's existing project
+  class GetAccountQuery
+    # Error if requesting to see forbidden account
+    class ForbiddenError < StandardError
+      def message
+        'You are not allowed to access that item'
+      end
+    end
+
+    def self.call(requestor:, username:)
+      account = Account.first(username: username)
+
+      policy = AccountPolicy.new(requestor, account)
+      policy.can_view? ? account : raise(ForbiddenError)
+    end
+  end
+end

--- a/app/services/get_contact_query.rb
+++ b/app/services/get_contact_query.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module LostNFound
+  # Service to get a contact with permission check
+  class GetContactQuery
+    # Error for unauthorized access
+    class ForbiddenError < StandardError
+      def message
+        'You are not allowed to access that contact'
+      end
+    end
+
+    # Error for contact not found
+    class NotFoundError < StandardError
+      def message
+        'We could not find that contact'
+      end
+    end
+
+    def self.call(account:, contact_id:)
+      contact = Contact.first(id: contact_id)
+      raise NotFoundError unless contact
+
+      item = contact.item
+      policy = ContactPolicy.new(account, item)
+
+      raise ForbiddenError unless policy.can_view?
+
+      contact
+    end
+  end
+end

--- a/app/services/get_item_query.rb
+++ b/app/services/get_item_query.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module LostNFound
+  # Service to get an item with permission check
+  class GetItemQuery
+    # Error for unauthorized access
+    class ForbiddenError < StandardError
+      def message
+        'You are not allowed to access that Item'
+      end
+    end
+
+    # Error for item not found
+    class NotFoundError < StandardError
+      def message
+        'We could not find that item'
+      end
+    end
+
+    def self.call(account:, item_id:)
+      item = Item.first(id: item_id)
+      raise NotFoundError unless item
+
+      policy = ItemPolicy.new(account, item)
+
+      # now is always true, but we keep it for clarity
+      raise ForbiddenError unless policy.can_view?
+
+      item.full_details.merge(policies: policy.summary)
+    end
+  end
+end


### PR DESCRIPTION
Added Files:
1. app/policies:
- account_policy.rb
- item_policy.rb
- contact_policy.rb
- tag_policy.rb
- item_scopes.rb

2. app/services:
- get_account_query.rb
- get_item_query.rb
- get_contact_query.rb

Edited Files:
1. app/models:
- item.rb

3. app/controllers:
- accounts.rb
- contacts.rb
- items.rb


# Please Check Following Requirements
1. Web API: Create policy objects in an app/policies folder

- [ ] Create at least one policy object per resource (e.g., ProjectPolicy, DocumentPolicy, etc.)
- [ ] Initialize policy objects with appropriate models (subject and object of policy)
- [ ] Create true/false predicate methods check for key actions (creation/deletion/updating/viewing, etc.)
- [ ] Make your predicate methods readable by using descriptive private predicates
- [ ] Use your policy objects in resource request routes to check authorization of account and resource

4. Web API: Create policy scope objects

- [ ] Scope objects should return lists of all relevant objects for a given action (e.g., viewable) and agents (e.g., current_account)
- [ ] Use your policy scopes to retrieve lists of objects to return on index routes (e.g., /api/v1/projects)

5. Policy summaries

- [ ] Web API: Create a summary method for each policy object that returns a hash of all predicate names and results
- [ ] Web API: Routes that return a resource should return a jsonified summary of its policy for the given account
